### PR TITLE
Alteração da descrição das roles.

### DIFF
--- a/src/main/java/br/com/diocesesjc/mesce/entity/Pessoa.java
+++ b/src/main/java/br/com/diocesesjc/mesce/entity/Pessoa.java
@@ -1,6 +1,5 @@
 package br.com.diocesesjc.mesce.entity;
 
-import java.time.LocalDate;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;

--- a/src/main/java/br/com/diocesesjc/mesce/enums/RoleType.java
+++ b/src/main/java/br/com/diocesesjc/mesce/enums/RoleType.java
@@ -2,11 +2,11 @@ package br.com.diocesesjc.mesce.enums;
 
 public enum RoleType {
     ROLE_ADMIN("Administrador"),
-    ROLE_SUPERVISOR("Supervisor"),
-    ROLE_COORDENADOR_REGIAO("Coordenador de região"),
+    ROLE_SUPERVISOR("Supervisor/Padre"),
+    ROLE_COORDENADOR_REGIAO("Coordenador de Região Pastoral"),
     ROLE_COORDENADOR_PASTORAL("Coordenador de pastoral"),
-    ROLE_COORDENADOR_NUCLEO("Coordenador de nucleo"),
-    ROLE_AGENTE("Agente");
+    ROLE_COORDENADOR_MESCE("Coordenador MESCE"),
+    ROLE_MINISTRO("Ministro");
 
     private final String description;
 


### PR DESCRIPTION
Foi feito uma alteração na descrição das roles.

Anteriormente:
```
"Administrador",
"Supervisor",
"Coordenador de região",
"Coordenador de pastoral",
"Coordenador de nucleo",
"Agente"
```

Atualmente:
```
"Administrador",
"Supervisor/Padre",
"Coordenador de Região Pastoral",
"Coordenador de pastoral",
"Coordenador MESCE",
"Ministro"
```